### PR TITLE
Add strlen to rom_functions on esp32s3

### DIFF
--- a/esp-wifi-sys/ld/esp32s3/rom_functions.x
+++ b/esp-wifi-sys/ld/esp32s3/rom_functions.x
@@ -2284,6 +2284,7 @@ phy_param_rom = 0x3fcef81c;
 strncpy = 0x40001224;
 strcpy = 0x40001218;
 strncmp = 0x4000123c;
+strlen = 0x40001248;
 
 /* from esp32s3.rom.api.ld*/
 PROVIDE ( esp_rom_delay_us = ets_delay_us );


### PR DESCRIPTION
I was getting linker issues due to a missing function. This change adds it, using the offsets from `esp32s3.rom.newlib.ld`