### PR TITLE
Fix pointer type passed to CStr::from_ptr

### DIFF
--- a/esp-wifi-sys/src/lib.rs
+++ b/esp-wifi-sys/src/lib.rs
@@ -55,7 +55,7 @@ pub mod log {
 
         let mut buf = [0u8; 512];
         vsnprintf(&mut buf as *mut u8, 512, format, args);
-        let res_str = core::ffi::CStr::from_ptr(&buf as *const _ as *const i8);
+        let res_str = core::ffi::CStr::from_ptr(&buf as *const _ as *const core::ffi::c_char);
         info!("{}", res_str.to_str().unwrap());
     }
 }


### PR DESCRIPTION
CStr::from_ptr takes a c_char, which is a type alias for either `i8` or `u8` depending on target.

fixes #487