### PR TITLE
include: add esp_rrm.h and esp_wnm.h to bindgen entry point

### DIFF
--- a/c/include/include.h
+++ b/c/include/include.h
@@ -29,6 +29,8 @@ struct timeval {
 #include "esp_private/wifi.h"
 #include "esp_private/wifi_os_adapter.h"
 #include "esp_wpa.h"
+#include "esp_rrm.h"
+#include "esp_wnm.h"
 #include "esp_phy_init.h"
 #include "phy.h"
 #include "esp_timer.h"

--- a/esp-wifi-sys-esp32/src/include.rs
+++ b/esp-wifi-sys-esp32/src/include.rs
@@ -11733,5 +11733,49 @@ pub struct timer_adpt {
     pub _address: u8,
 }
 
+#[doc = " @brief  Callback function type to get neighbor report\n\n @param  ctx: neighbor report context\n @param  report: neighbor report\n @param  report_len: neighbor report length\n\n @return\n    - void"]
+pub type neighbor_rep_request_cb = ::core::option::Option<
+    unsafe extern "C" fn(ctx: *mut crate::c_types::c_void, report: *const u8, report_len: usize),
+>;
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n\n @deprecated This function is deprecated and will be removed in the future.\n             Please use 'esp_rrm_send_neighbor_report_request'\n @param  cb: callback function for neighbor report\n @param  cb_ctx: callback context\n\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_rep_request(
+        cb: neighbor_rep_request_cb,
+        cb_ctx: *mut crate::c_types::c_void,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_report_request() -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check RRM capability of connected AP\n\n @return\n    - true: AP supports RRM\n    - false: AP does not support RRM or station not connected to AP"]
+    pub fn esp_rrm_is_rrm_supported_connection() -> bool;
+}
+pub const btm_query_reason_REASON_UNSPECIFIED: btm_query_reason = 0;
+pub const btm_query_reason_REASON_FRAME_LOSS: btm_query_reason = 1;
+pub const btm_query_reason_REASON_DELAY: btm_query_reason = 2;
+pub const btm_query_reason_REASON_BANDWIDTH: btm_query_reason = 3;
+pub const btm_query_reason_REASON_LOAD_BALANCE: btm_query_reason = 4;
+pub const btm_query_reason_REASON_RSSI: btm_query_reason = 5;
+pub const btm_query_reason_REASON_RETRANSMISSIONS: btm_query_reason = 6;
+pub const btm_query_reason_REASON_INTERFERENCE: btm_query_reason = 7;
+pub const btm_query_reason_REASON_GRAY_ZONE: btm_query_reason = 8;
+pub const btm_query_reason_REASON_PREMIUM_AP: btm_query_reason = 9;
+#[doc = " enum btm_query_reason: Reason code for sending btm query"]
+pub type btm_query_reason = crate::c_types::c_uint;
+extern "C" {
+    #[doc = " @brief  Send bss transition query to connected AP\n\n @param  query_reason: reason for sending query\n @param  btm_candidates: btm candidates list if available\n @param  cand_list: whether candidate list to be included from scan results available in supplicant's cache.\n\n @return\n    - 0: success\n    - -1: AP does not support BTM\n    - -2: station not connected to AP"]
+    pub fn esp_wnm_send_bss_transition_mgmt_query(
+        query_reason: btm_query_reason,
+        btm_candidates: *const crate::c_types::c_char,
+        cand_list: crate::c_types::c_int,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check bss transition capability of connected AP\n\n @return\n    - true: AP supports BTM\n    - false: AP does not support BTM or station not connected to AP"]
+    pub fn esp_wnm_is_btm_supported_connection() -> bool;
+}
+
 unsafe impl Sync for wifi_init_config_t {}
 unsafe impl Sync for wifi_osi_funcs_t {}

--- a/esp-wifi-sys-esp32c2/src/include.rs
+++ b/esp-wifi-sys-esp32c2/src/include.rs
@@ -12079,5 +12079,49 @@ pub struct timer_adpt {
 }
 pub type __builtin_va_list = *mut crate::c_types::c_void;
 
+#[doc = " @brief  Callback function type to get neighbor report\n\n @param  ctx: neighbor report context\n @param  report: neighbor report\n @param  report_len: neighbor report length\n\n @return\n    - void"]
+pub type neighbor_rep_request_cb = ::core::option::Option<
+    unsafe extern "C" fn(ctx: *mut crate::c_types::c_void, report: *const u8, report_len: usize),
+>;
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n\n @deprecated This function is deprecated and will be removed in the future.\n             Please use 'esp_rrm_send_neighbor_report_request'\n @param  cb: callback function for neighbor report\n @param  cb_ctx: callback context\n\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_rep_request(
+        cb: neighbor_rep_request_cb,
+        cb_ctx: *mut crate::c_types::c_void,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_report_request() -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check RRM capability of connected AP\n\n @return\n    - true: AP supports RRM\n    - false: AP does not support RRM or station not connected to AP"]
+    pub fn esp_rrm_is_rrm_supported_connection() -> bool;
+}
+pub const btm_query_reason_REASON_UNSPECIFIED: btm_query_reason = 0;
+pub const btm_query_reason_REASON_FRAME_LOSS: btm_query_reason = 1;
+pub const btm_query_reason_REASON_DELAY: btm_query_reason = 2;
+pub const btm_query_reason_REASON_BANDWIDTH: btm_query_reason = 3;
+pub const btm_query_reason_REASON_LOAD_BALANCE: btm_query_reason = 4;
+pub const btm_query_reason_REASON_RSSI: btm_query_reason = 5;
+pub const btm_query_reason_REASON_RETRANSMISSIONS: btm_query_reason = 6;
+pub const btm_query_reason_REASON_INTERFERENCE: btm_query_reason = 7;
+pub const btm_query_reason_REASON_GRAY_ZONE: btm_query_reason = 8;
+pub const btm_query_reason_REASON_PREMIUM_AP: btm_query_reason = 9;
+#[doc = " enum btm_query_reason: Reason code for sending btm query"]
+pub type btm_query_reason = crate::c_types::c_uint;
+extern "C" {
+    #[doc = " @brief  Send bss transition query to connected AP\n\n @param  query_reason: reason for sending query\n @param  btm_candidates: btm candidates list if available\n @param  cand_list: whether candidate list to be included from scan results available in supplicant's cache.\n\n @return\n    - 0: success\n    - -1: AP does not support BTM\n    - -2: station not connected to AP"]
+    pub fn esp_wnm_send_bss_transition_mgmt_query(
+        query_reason: btm_query_reason,
+        btm_candidates: *const crate::c_types::c_char,
+        cand_list: crate::c_types::c_int,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check bss transition capability of connected AP\n\n @return\n    - true: AP supports BTM\n    - false: AP does not support BTM or station not connected to AP"]
+    pub fn esp_wnm_is_btm_supported_connection() -> bool;
+}
+
 unsafe impl Sync for wifi_init_config_t {}
 unsafe impl Sync for wifi_osi_funcs_t {}

--- a/esp-wifi-sys-esp32c3/src/include.rs
+++ b/esp-wifi-sys-esp32c3/src/include.rs
@@ -11823,5 +11823,49 @@ pub struct timer_adpt {
 }
 pub type __builtin_va_list = *mut crate::c_types::c_void;
 
+#[doc = " @brief  Callback function type to get neighbor report\n\n @param  ctx: neighbor report context\n @param  report: neighbor report\n @param  report_len: neighbor report length\n\n @return\n    - void"]
+pub type neighbor_rep_request_cb = ::core::option::Option<
+    unsafe extern "C" fn(ctx: *mut crate::c_types::c_void, report: *const u8, report_len: usize),
+>;
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n\n @deprecated This function is deprecated and will be removed in the future.\n             Please use 'esp_rrm_send_neighbor_report_request'\n @param  cb: callback function for neighbor report\n @param  cb_ctx: callback context\n\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_rep_request(
+        cb: neighbor_rep_request_cb,
+        cb_ctx: *mut crate::c_types::c_void,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_report_request() -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check RRM capability of connected AP\n\n @return\n    - true: AP supports RRM\n    - false: AP does not support RRM or station not connected to AP"]
+    pub fn esp_rrm_is_rrm_supported_connection() -> bool;
+}
+pub const btm_query_reason_REASON_UNSPECIFIED: btm_query_reason = 0;
+pub const btm_query_reason_REASON_FRAME_LOSS: btm_query_reason = 1;
+pub const btm_query_reason_REASON_DELAY: btm_query_reason = 2;
+pub const btm_query_reason_REASON_BANDWIDTH: btm_query_reason = 3;
+pub const btm_query_reason_REASON_LOAD_BALANCE: btm_query_reason = 4;
+pub const btm_query_reason_REASON_RSSI: btm_query_reason = 5;
+pub const btm_query_reason_REASON_RETRANSMISSIONS: btm_query_reason = 6;
+pub const btm_query_reason_REASON_INTERFERENCE: btm_query_reason = 7;
+pub const btm_query_reason_REASON_GRAY_ZONE: btm_query_reason = 8;
+pub const btm_query_reason_REASON_PREMIUM_AP: btm_query_reason = 9;
+#[doc = " enum btm_query_reason: Reason code for sending btm query"]
+pub type btm_query_reason = crate::c_types::c_uint;
+extern "C" {
+    #[doc = " @brief  Send bss transition query to connected AP\n\n @param  query_reason: reason for sending query\n @param  btm_candidates: btm candidates list if available\n @param  cand_list: whether candidate list to be included from scan results available in supplicant's cache.\n\n @return\n    - 0: success\n    - -1: AP does not support BTM\n    - -2: station not connected to AP"]
+    pub fn esp_wnm_send_bss_transition_mgmt_query(
+        query_reason: btm_query_reason,
+        btm_candidates: *const crate::c_types::c_char,
+        cand_list: crate::c_types::c_int,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check bss transition capability of connected AP\n\n @return\n    - true: AP supports BTM\n    - false: AP does not support BTM or station not connected to AP"]
+    pub fn esp_wnm_is_btm_supported_connection() -> bool;
+}
+
 unsafe impl Sync for wifi_init_config_t {}
 unsafe impl Sync for wifi_osi_funcs_t {}

--- a/esp-wifi-sys-esp32c5/src/include.rs
+++ b/esp-wifi-sys-esp32c5/src/include.rs
@@ -26847,5 +26847,49 @@ pub struct timer_adpt {
 }
 pub type __builtin_va_list = *mut crate::c_types::c_void;
 
+#[doc = " @brief  Callback function type to get neighbor report\n\n @param  ctx: neighbor report context\n @param  report: neighbor report\n @param  report_len: neighbor report length\n\n @return\n    - void"]
+pub type neighbor_rep_request_cb = ::core::option::Option<
+    unsafe extern "C" fn(ctx: *mut crate::c_types::c_void, report: *const u8, report_len: usize),
+>;
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n\n @deprecated This function is deprecated and will be removed in the future.\n             Please use 'esp_rrm_send_neighbor_report_request'\n @param  cb: callback function for neighbor report\n @param  cb_ctx: callback context\n\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_rep_request(
+        cb: neighbor_rep_request_cb,
+        cb_ctx: *mut crate::c_types::c_void,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_report_request() -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check RRM capability of connected AP\n\n @return\n    - true: AP supports RRM\n    - false: AP does not support RRM or station not connected to AP"]
+    pub fn esp_rrm_is_rrm_supported_connection() -> bool;
+}
+pub const btm_query_reason_REASON_UNSPECIFIED: btm_query_reason = 0;
+pub const btm_query_reason_REASON_FRAME_LOSS: btm_query_reason = 1;
+pub const btm_query_reason_REASON_DELAY: btm_query_reason = 2;
+pub const btm_query_reason_REASON_BANDWIDTH: btm_query_reason = 3;
+pub const btm_query_reason_REASON_LOAD_BALANCE: btm_query_reason = 4;
+pub const btm_query_reason_REASON_RSSI: btm_query_reason = 5;
+pub const btm_query_reason_REASON_RETRANSMISSIONS: btm_query_reason = 6;
+pub const btm_query_reason_REASON_INTERFERENCE: btm_query_reason = 7;
+pub const btm_query_reason_REASON_GRAY_ZONE: btm_query_reason = 8;
+pub const btm_query_reason_REASON_PREMIUM_AP: btm_query_reason = 9;
+#[doc = " enum btm_query_reason: Reason code for sending btm query"]
+pub type btm_query_reason = crate::c_types::c_uint;
+extern "C" {
+    #[doc = " @brief  Send bss transition query to connected AP\n\n @param  query_reason: reason for sending query\n @param  btm_candidates: btm candidates list if available\n @param  cand_list: whether candidate list to be included from scan results available in supplicant's cache.\n\n @return\n    - 0: success\n    - -1: AP does not support BTM\n    - -2: station not connected to AP"]
+    pub fn esp_wnm_send_bss_transition_mgmt_query(
+        query_reason: btm_query_reason,
+        btm_candidates: *const crate::c_types::c_char,
+        cand_list: crate::c_types::c_int,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check bss transition capability of connected AP\n\n @return\n    - true: AP supports BTM\n    - false: AP does not support BTM or station not connected to AP"]
+    pub fn esp_wnm_is_btm_supported_connection() -> bool;
+}
+
 unsafe impl Sync for wifi_init_config_t {}
 unsafe impl Sync for wifi_osi_funcs_t {}

--- a/esp-wifi-sys-esp32c6/src/include.rs
+++ b/esp-wifi-sys-esp32c6/src/include.rs
@@ -24971,5 +24971,49 @@ pub struct timer_adpt {
 }
 pub type __builtin_va_list = *mut crate::c_types::c_void;
 
+#[doc = " @brief  Callback function type to get neighbor report\n\n @param  ctx: neighbor report context\n @param  report: neighbor report\n @param  report_len: neighbor report length\n\n @return\n    - void"]
+pub type neighbor_rep_request_cb = ::core::option::Option<
+    unsafe extern "C" fn(ctx: *mut crate::c_types::c_void, report: *const u8, report_len: usize),
+>;
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n\n @deprecated This function is deprecated and will be removed in the future.\n             Please use 'esp_rrm_send_neighbor_report_request'\n @param  cb: callback function for neighbor report\n @param  cb_ctx: callback context\n\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_rep_request(
+        cb: neighbor_rep_request_cb,
+        cb_ctx: *mut crate::c_types::c_void,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_report_request() -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check RRM capability of connected AP\n\n @return\n    - true: AP supports RRM\n    - false: AP does not support RRM or station not connected to AP"]
+    pub fn esp_rrm_is_rrm_supported_connection() -> bool;
+}
+pub const btm_query_reason_REASON_UNSPECIFIED: btm_query_reason = 0;
+pub const btm_query_reason_REASON_FRAME_LOSS: btm_query_reason = 1;
+pub const btm_query_reason_REASON_DELAY: btm_query_reason = 2;
+pub const btm_query_reason_REASON_BANDWIDTH: btm_query_reason = 3;
+pub const btm_query_reason_REASON_LOAD_BALANCE: btm_query_reason = 4;
+pub const btm_query_reason_REASON_RSSI: btm_query_reason = 5;
+pub const btm_query_reason_REASON_RETRANSMISSIONS: btm_query_reason = 6;
+pub const btm_query_reason_REASON_INTERFERENCE: btm_query_reason = 7;
+pub const btm_query_reason_REASON_GRAY_ZONE: btm_query_reason = 8;
+pub const btm_query_reason_REASON_PREMIUM_AP: btm_query_reason = 9;
+#[doc = " enum btm_query_reason: Reason code for sending btm query"]
+pub type btm_query_reason = crate::c_types::c_uint;
+extern "C" {
+    #[doc = " @brief  Send bss transition query to connected AP\n\n @param  query_reason: reason for sending query\n @param  btm_candidates: btm candidates list if available\n @param  cand_list: whether candidate list to be included from scan results available in supplicant's cache.\n\n @return\n    - 0: success\n    - -1: AP does not support BTM\n    - -2: station not connected to AP"]
+    pub fn esp_wnm_send_bss_transition_mgmt_query(
+        query_reason: btm_query_reason,
+        btm_candidates: *const crate::c_types::c_char,
+        cand_list: crate::c_types::c_int,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check bss transition capability of connected AP\n\n @return\n    - true: AP supports BTM\n    - false: AP does not support BTM or station not connected to AP"]
+    pub fn esp_wnm_is_btm_supported_connection() -> bool;
+}
+
 unsafe impl Sync for wifi_init_config_t {}
 unsafe impl Sync for wifi_osi_funcs_t {}

--- a/esp-wifi-sys-esp32c61/src/include.rs
+++ b/esp-wifi-sys-esp32c61/src/include.rs
@@ -25139,5 +25139,49 @@ pub struct timer_adpt {
 }
 pub type __builtin_va_list = *mut crate::c_types::c_void;
 
+#[doc = " @brief  Callback function type to get neighbor report\n\n @param  ctx: neighbor report context\n @param  report: neighbor report\n @param  report_len: neighbor report length\n\n @return\n    - void"]
+pub type neighbor_rep_request_cb = ::core::option::Option<
+    unsafe extern "C" fn(ctx: *mut crate::c_types::c_void, report: *const u8, report_len: usize),
+>;
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n\n @deprecated This function is deprecated and will be removed in the future.\n             Please use 'esp_rrm_send_neighbor_report_request'\n @param  cb: callback function for neighbor report\n @param  cb_ctx: callback context\n\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_rep_request(
+        cb: neighbor_rep_request_cb,
+        cb_ctx: *mut crate::c_types::c_void,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_report_request() -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check RRM capability of connected AP\n\n @return\n    - true: AP supports RRM\n    - false: AP does not support RRM or station not connected to AP"]
+    pub fn esp_rrm_is_rrm_supported_connection() -> bool;
+}
+pub const btm_query_reason_REASON_UNSPECIFIED: btm_query_reason = 0;
+pub const btm_query_reason_REASON_FRAME_LOSS: btm_query_reason = 1;
+pub const btm_query_reason_REASON_DELAY: btm_query_reason = 2;
+pub const btm_query_reason_REASON_BANDWIDTH: btm_query_reason = 3;
+pub const btm_query_reason_REASON_LOAD_BALANCE: btm_query_reason = 4;
+pub const btm_query_reason_REASON_RSSI: btm_query_reason = 5;
+pub const btm_query_reason_REASON_RETRANSMISSIONS: btm_query_reason = 6;
+pub const btm_query_reason_REASON_INTERFERENCE: btm_query_reason = 7;
+pub const btm_query_reason_REASON_GRAY_ZONE: btm_query_reason = 8;
+pub const btm_query_reason_REASON_PREMIUM_AP: btm_query_reason = 9;
+#[doc = " enum btm_query_reason: Reason code for sending btm query"]
+pub type btm_query_reason = crate::c_types::c_uint;
+extern "C" {
+    #[doc = " @brief  Send bss transition query to connected AP\n\n @param  query_reason: reason for sending query\n @param  btm_candidates: btm candidates list if available\n @param  cand_list: whether candidate list to be included from scan results available in supplicant's cache.\n\n @return\n    - 0: success\n    - -1: AP does not support BTM\n    - -2: station not connected to AP"]
+    pub fn esp_wnm_send_bss_transition_mgmt_query(
+        query_reason: btm_query_reason,
+        btm_candidates: *const crate::c_types::c_char,
+        cand_list: crate::c_types::c_int,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check bss transition capability of connected AP\n\n @return\n    - true: AP supports BTM\n    - false: AP does not support BTM or station not connected to AP"]
+    pub fn esp_wnm_is_btm_supported_connection() -> bool;
+}
+
 unsafe impl Sync for wifi_init_config_t {}
 unsafe impl Sync for wifi_osi_funcs_t {}

--- a/esp-wifi-sys-esp32h2/src/include.rs
+++ b/esp-wifi-sys-esp32h2/src/include.rs
@@ -24116,5 +24116,49 @@ pub struct timer_adpt {
 }
 pub type __builtin_va_list = *mut crate::c_types::c_void;
 
+#[doc = " @brief  Callback function type to get neighbor report\n\n @param  ctx: neighbor report context\n @param  report: neighbor report\n @param  report_len: neighbor report length\n\n @return\n    - void"]
+pub type neighbor_rep_request_cb = ::core::option::Option<
+    unsafe extern "C" fn(ctx: *mut crate::c_types::c_void, report: *const u8, report_len: usize),
+>;
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n\n @deprecated This function is deprecated and will be removed in the future.\n             Please use 'esp_rrm_send_neighbor_report_request'\n @param  cb: callback function for neighbor report\n @param  cb_ctx: callback context\n\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_rep_request(
+        cb: neighbor_rep_request_cb,
+        cb_ctx: *mut crate::c_types::c_void,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_report_request() -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check RRM capability of connected AP\n\n @return\n    - true: AP supports RRM\n    - false: AP does not support RRM or station not connected to AP"]
+    pub fn esp_rrm_is_rrm_supported_connection() -> bool;
+}
+pub const btm_query_reason_REASON_UNSPECIFIED: btm_query_reason = 0;
+pub const btm_query_reason_REASON_FRAME_LOSS: btm_query_reason = 1;
+pub const btm_query_reason_REASON_DELAY: btm_query_reason = 2;
+pub const btm_query_reason_REASON_BANDWIDTH: btm_query_reason = 3;
+pub const btm_query_reason_REASON_LOAD_BALANCE: btm_query_reason = 4;
+pub const btm_query_reason_REASON_RSSI: btm_query_reason = 5;
+pub const btm_query_reason_REASON_RETRANSMISSIONS: btm_query_reason = 6;
+pub const btm_query_reason_REASON_INTERFERENCE: btm_query_reason = 7;
+pub const btm_query_reason_REASON_GRAY_ZONE: btm_query_reason = 8;
+pub const btm_query_reason_REASON_PREMIUM_AP: btm_query_reason = 9;
+#[doc = " enum btm_query_reason: Reason code for sending btm query"]
+pub type btm_query_reason = crate::c_types::c_uint;
+extern "C" {
+    #[doc = " @brief  Send bss transition query to connected AP\n\n @param  query_reason: reason for sending query\n @param  btm_candidates: btm candidates list if available\n @param  cand_list: whether candidate list to be included from scan results available in supplicant's cache.\n\n @return\n    - 0: success\n    - -1: AP does not support BTM\n    - -2: station not connected to AP"]
+    pub fn esp_wnm_send_bss_transition_mgmt_query(
+        query_reason: btm_query_reason,
+        btm_candidates: *const crate::c_types::c_char,
+        cand_list: crate::c_types::c_int,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check bss transition capability of connected AP\n\n @return\n    - true: AP supports BTM\n    - false: AP does not support BTM or station not connected to AP"]
+    pub fn esp_wnm_is_btm_supported_connection() -> bool;
+}
+
 unsafe impl Sync for wifi_init_config_t {}
 unsafe impl Sync for wifi_osi_funcs_t {}

--- a/esp-wifi-sys-esp32s2/src/include.rs
+++ b/esp-wifi-sys-esp32s2/src/include.rs
@@ -10938,5 +10938,49 @@ pub struct timer_adpt {
     pub _address: u8,
 }
 
+#[doc = " @brief  Callback function type to get neighbor report\n\n @param  ctx: neighbor report context\n @param  report: neighbor report\n @param  report_len: neighbor report length\n\n @return\n    - void"]
+pub type neighbor_rep_request_cb = ::core::option::Option<
+    unsafe extern "C" fn(ctx: *mut crate::c_types::c_void, report: *const u8, report_len: usize),
+>;
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n\n @deprecated This function is deprecated and will be removed in the future.\n             Please use 'esp_rrm_send_neighbor_report_request'\n @param  cb: callback function for neighbor report\n @param  cb_ctx: callback context\n\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_rep_request(
+        cb: neighbor_rep_request_cb,
+        cb_ctx: *mut crate::c_types::c_void,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_report_request() -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check RRM capability of connected AP\n\n @return\n    - true: AP supports RRM\n    - false: AP does not support RRM or station not connected to AP"]
+    pub fn esp_rrm_is_rrm_supported_connection() -> bool;
+}
+pub const btm_query_reason_REASON_UNSPECIFIED: btm_query_reason = 0;
+pub const btm_query_reason_REASON_FRAME_LOSS: btm_query_reason = 1;
+pub const btm_query_reason_REASON_DELAY: btm_query_reason = 2;
+pub const btm_query_reason_REASON_BANDWIDTH: btm_query_reason = 3;
+pub const btm_query_reason_REASON_LOAD_BALANCE: btm_query_reason = 4;
+pub const btm_query_reason_REASON_RSSI: btm_query_reason = 5;
+pub const btm_query_reason_REASON_RETRANSMISSIONS: btm_query_reason = 6;
+pub const btm_query_reason_REASON_INTERFERENCE: btm_query_reason = 7;
+pub const btm_query_reason_REASON_GRAY_ZONE: btm_query_reason = 8;
+pub const btm_query_reason_REASON_PREMIUM_AP: btm_query_reason = 9;
+#[doc = " enum btm_query_reason: Reason code for sending btm query"]
+pub type btm_query_reason = crate::c_types::c_uint;
+extern "C" {
+    #[doc = " @brief  Send bss transition query to connected AP\n\n @param  query_reason: reason for sending query\n @param  btm_candidates: btm candidates list if available\n @param  cand_list: whether candidate list to be included from scan results available in supplicant's cache.\n\n @return\n    - 0: success\n    - -1: AP does not support BTM\n    - -2: station not connected to AP"]
+    pub fn esp_wnm_send_bss_transition_mgmt_query(
+        query_reason: btm_query_reason,
+        btm_candidates: *const crate::c_types::c_char,
+        cand_list: crate::c_types::c_int,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check bss transition capability of connected AP\n\n @return\n    - true: AP supports BTM\n    - false: AP does not support BTM or station not connected to AP"]
+    pub fn esp_wnm_is_btm_supported_connection() -> bool;
+}
+
 unsafe impl Sync for wifi_init_config_t {}
 unsafe impl Sync for wifi_osi_funcs_t {}

--- a/esp-wifi-sys-esp32s3/src/include.rs
+++ b/esp-wifi-sys-esp32s3/src/include.rs
@@ -12046,5 +12046,49 @@ pub struct timer_adpt {
     pub _address: u8,
 }
 
+#[doc = " @brief  Callback function type to get neighbor report\n\n @param  ctx: neighbor report context\n @param  report: neighbor report\n @param  report_len: neighbor report length\n\n @return\n    - void"]
+pub type neighbor_rep_request_cb = ::core::option::Option<
+    unsafe extern "C" fn(ctx: *mut crate::c_types::c_void, report: *const u8, report_len: usize),
+>;
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n\n @deprecated This function is deprecated and will be removed in the future.\n             Please use 'esp_rrm_send_neighbor_report_request'\n @param  cb: callback function for neighbor report\n @param  cb_ctx: callback context\n\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_rep_request(
+        cb: neighbor_rep_request_cb,
+        cb_ctx: *mut crate::c_types::c_void,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Send Radio measurement neighbor report request to connected AP\n @return\n    - 0: success\n    - -1: AP does not support RRM\n    - -2: station not connected to AP"]
+    pub fn esp_rrm_send_neighbor_report_request() -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check RRM capability of connected AP\n\n @return\n    - true: AP supports RRM\n    - false: AP does not support RRM or station not connected to AP"]
+    pub fn esp_rrm_is_rrm_supported_connection() -> bool;
+}
+pub const btm_query_reason_REASON_UNSPECIFIED: btm_query_reason = 0;
+pub const btm_query_reason_REASON_FRAME_LOSS: btm_query_reason = 1;
+pub const btm_query_reason_REASON_DELAY: btm_query_reason = 2;
+pub const btm_query_reason_REASON_BANDWIDTH: btm_query_reason = 3;
+pub const btm_query_reason_REASON_LOAD_BALANCE: btm_query_reason = 4;
+pub const btm_query_reason_REASON_RSSI: btm_query_reason = 5;
+pub const btm_query_reason_REASON_RETRANSMISSIONS: btm_query_reason = 6;
+pub const btm_query_reason_REASON_INTERFERENCE: btm_query_reason = 7;
+pub const btm_query_reason_REASON_GRAY_ZONE: btm_query_reason = 8;
+pub const btm_query_reason_REASON_PREMIUM_AP: btm_query_reason = 9;
+#[doc = " enum btm_query_reason: Reason code for sending btm query"]
+pub type btm_query_reason = crate::c_types::c_uint;
+extern "C" {
+    #[doc = " @brief  Send bss transition query to connected AP\n\n @param  query_reason: reason for sending query\n @param  btm_candidates: btm candidates list if available\n @param  cand_list: whether candidate list to be included from scan results available in supplicant's cache.\n\n @return\n    - 0: success\n    - -1: AP does not support BTM\n    - -2: station not connected to AP"]
+    pub fn esp_wnm_send_bss_transition_mgmt_query(
+        query_reason: btm_query_reason,
+        btm_candidates: *const crate::c_types::c_char,
+        cand_list: crate::c_types::c_int,
+    ) -> crate::c_types::c_int;
+}
+extern "C" {
+    #[doc = " @brief  Check bss transition capability of connected AP\n\n @return\n    - true: AP supports BTM\n    - false: AP does not support BTM or station not connected to AP"]
+    pub fn esp_wnm_is_btm_supported_connection() -> bool;
+}
+
 unsafe impl Sync for wifi_init_config_t {}
 unsafe impl Sync for wifi_osi_funcs_t {}


### PR DESCRIPTION
## Summary

**Scope: headers / bindgen only. No blob change, no `libwpa_supplicant.a` change.**

`esp_rrm.h` and `esp_wnm.h` already ship in `c/include/` and `c/headers/`, and the symbols are already **linkable from the archive currently in this repo** — they are just not reachable from Rust, because the headers are not pulled into `c/include/include.h` (the bindgen entry point).

Verified against the blob on `main`:

```
$ nm -g --defined-only esp-wifi-sys-esp32c6/libs/libwpa_supplicant.a | grep -E 'esp_rrm_|esp_wnm_'
00000000 T esp_rrm_is_rrm_supported_connection
00000000 T esp_rrm_send_neighbor_report_request
00000000 T esp_rrm_send_neighbor_rep_request
00000000 T esp_wnm_is_btm_supported_connection
00000000 T esp_wnm_send_bss_transition_mgmt_query
```

So this PR is purely about emitting the FFI for what is already there:

- `esp_rrm_send_neighbor_report_request`
- `esp_rrm_is_rrm_supported_connection`
- `esp_rrm_send_neighbor_rep_request` (deprecated alias)
- `esp_wnm_send_bss_transition_mgmt_query`
- `esp_wnm_is_btm_supported_connection`
- `btm_query_reason` / `neighbor_rep_request_cb`

This lets *callers* (esp-radio or application code) request 802.11k neighbor reports and 802.11v BTM transitions from Rust. It does not enable those features by itself and changes no existing behaviour — the diff is **+398 / −0**.

### A note on the generated output

`cargo xtask` was run to produce this. A full regeneration also rewrote several thousand unrelated lines in every `include.rs`, because my local Clang (23) formats/orders things differently from whatever produced the committed output. Rather than bury the change in that noise, the commit contains **only the new RRM/WNM block**, appended to each chip's `include.rs`. The block is byte-identical across all nine chips.

If you would rather have a full, canonical regeneration from your own toolchain, say the word and I will either redo it or hand this over — I did not want to force an unrelated whole-file churn on you.

## Relationship to the other two PRs

These are three independent layers. **None of them blocks this one**, and this one blocks none of them.

| PR | Layer | Depends on this? |
|---|---|---|
| [esp-hal#6239](https://github.com/esp-rs/esp-hal/pull/6239) | esp-radio: `rm_enabled`/`btm_enabled` STA flags + `EventInfo::StationNeighborRep`. Uses `wifi_sta_config_t` bits and an existing event — no new FFI. | No |
| [esp-wireless-drivers-3rdparty#9](https://github.com/esp-rs/esp-wireless-drivers-3rdparty/pull/9) | 802.11r blob rebuild (`CONFIG_ESP_WIFI_11R_SUPPORT`). Different feature (FT), needs an actual blob rebuild. | No |

The only ordering that exists is a soft one: #6239 lets you *turn 802.11k on*, and this PR lets you *ask the AP for a neighbor report*. They are more useful together, but each is independently correct and mergeable.

## Context

Downstream: [LongFred](https://github.com/dcc-bigfred/longfred), ESP32-C6 wireless DCC throttles that need sub-second roaming across several APs. With this, the firmware can ask the AP for neighbors instead of doing a full channel scan when RSSI drops.

Reference: [esp-rs/esp-hal#1624](https://github.com/esp-rs/esp-hal/issues/1624)

## Test plan

- [x] `cargo xtask` run; RRM/WNM FFI present in all nine `esp-wifi-sys-*/src/include.rs`, identical block in each
- [x] `cargo build -p esp-wifi-sys-<chip>` passes for `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32c61`, `esp32h2`
- [x] `rustfmt --check` clean on all nine `include.rs` (also confirms the Xtensa files parse; I have no Xtensa toolchain locally, so `esp32`/`esp32s2`/`esp32s3` were not compiled — the added block is arch-independent)
- [x] Symbols confirmed present in the existing archive (see above), so no blob work is implied
